### PR TITLE
Add Prompt Library page

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -5,10 +5,22 @@ export default function Header({ name }) {
     <header className="pt-20 pb-12">
       <div className="block w-12 h-12 mx-auto mb-4 rounded-full bg-gradient-conic from-gradient-3 to-gradient-4" />
       <p className="text-2xl text-center dark:text-white">
-        <Link href="/">
-          {name}
-        </Link>
+        <Link href="/">{name}</Link>
       </p>
+      <nav className="flex justify-center mt-6 space-x-6">
+        <Link
+          href="/"
+          className="font-semibold hover:underline dark:text-white"
+        >
+          Home
+        </Link>
+        <Link
+          href="/prompt-library"
+          className="font-semibold hover:underline dark:text-white"
+        >
+          Prompt Library
+        </Link>
+      </nav>
     </header>
   );
 }

--- a/pages/prompt-library.js
+++ b/pages/prompt-library.js
@@ -1,0 +1,84 @@
+import Footer from '../components/Footer';
+import Header from '../components/Header';
+import Layout, { GradientBackground } from '../components/Layout';
+import SEO from '../components/SEO';
+import { getGlobalData } from '../utils/global-data';
+
+const prompts = [
+  {
+    id: 1,
+    text: 'Explain the concept of machine learning in simple terms.',
+  },
+  {
+    id: 2,
+    text: 'Generate a list of creative marketing slogans for a new eco-friendly brand.',
+  },
+  {
+    id: 3,
+    text: 'Write a short story set on Mars with a surprise ending.',
+  },
+  {
+    id: 4,
+    text: 'Give me five tips for staying productive while working remotely.',
+  },
+  {
+    id: 5,
+    text: 'Create a meal plan for a week that is high in protein and low in carbs.',
+  },
+];
+
+export default function PromptLibrary({ globalData }) {
+  const copyPrompt = (text) => {
+    if (typeof navigator !== 'undefined') {
+      navigator.clipboard.writeText(text);
+    }
+  };
+
+  return (
+    <Layout>
+      <SEO
+        title={`Prompt Library - ${globalData.name}`}
+        description="A collection of useful prompts."
+      />
+      <Header name={globalData.name} />
+      <main className="w-full">
+        <h1 className="mb-12 text-3xl text-center lg:text-5xl">
+          Prompt Library
+        </h1>
+        <ul className="w-full">
+          {prompts.map((prompt) => (
+            <li
+              key={prompt.id}
+              className="transition bg-white border border-b-0 border-gray-800 md:first:rounded-t-lg md:last:rounded-b-lg backdrop-blur-lg dark:bg-black dark:bg-opacity-30 bg-opacity-10 hover:bg-opacity-20 dark:hover:bg-opacity-50 dark:border-white border-opacity-10 dark:border-opacity-10 last:border-b hover:border-b hovered-sibling:border-t-0"
+            >
+              <div className="flex items-start justify-between px-6 py-6 lg:py-10 lg:px-16">
+                <pre className="whitespace-pre-wrap">{prompt.text}</pre>
+                <button
+                  onClick={() => copyPrompt(prompt.text)}
+                  className="px-3 py-2 ml-4 text-sm text-white bg-primary rounded"
+                >
+                  Copy
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </main>
+      <Footer copyrightText={globalData.footerText} />
+      <GradientBackground
+        variant="large"
+        className="fixed top-20 opacity-40 dark:opacity-60"
+      />
+      <GradientBackground
+        variant="small"
+        className="absolute bottom-0 opacity-20 dark:opacity-10"
+      />
+    </Layout>
+  );
+}
+
+export function getStaticProps() {
+  const globalData = getGlobalData();
+
+  return { props: { globalData } };
+}


### PR DESCRIPTION
## Summary
- add a Prompt Library page with copyable prompts
- create navigation links for the new page and home

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687679fc3e44832cbe96ce61c57945b3