### PR TITLE
Update theme toggle and prompt library

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -49,7 +49,7 @@ const moonIcon = (
 
 const ThemeSwitcher = () => {
   return (
-    <div className="flex justify-center p-1 mt-6 bg-white dark:bg-gray-900 rounded-3xl">
+    <div className="fixed top-4 right-4 flex justify-center p-1 bg-white dark:bg-gray-900 rounded-3xl">
       <button
         type="button"
         aria-label="Use Dark Mode"
@@ -57,7 +57,7 @@ const ThemeSwitcher = () => {
           document.documentElement.classList.add('dark');
           localStorage.setItem('theme', 'dark');
         }}
-        className="flex items-center justify-center w-24 h-10 p-2 pr-2 transition dark:bg-primary rounded-3xl align-center"
+        className="flex items-center justify-center w-[4.5rem] h-[1.875rem] p-2 pr-2 transition dark:bg-primary rounded-3xl align-center"
       >
         {moonIcon}
       </button>
@@ -69,7 +69,7 @@ const ThemeSwitcher = () => {
           document.documentElement.classList.remove('dark');
           localStorage.setItem('theme', 'light');
         }}
-        className="flex items-center justify-center w-24 h-10 p-2 pr-2 transition bg-primary dark:bg-transparent rounded-3xl align-center"
+        className="flex items-center justify-center w-[4.5rem] h-[1.875rem] p-2 pr-2 transition bg-primary dark:bg-transparent rounded-3xl align-center"
       >
         {sunIcon}
       </button>

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -16,15 +16,16 @@ export function GradientBackground({ variant, className }) {
 
 export default function Layout({ children }) {
   const setAppTheme = () => {
-    const darkMode = localStorage.getItem('theme') === 'dark';
-    const lightMode = localStorage.getItem('theme') === 'light';
+    const storedTheme = localStorage.getItem('theme');
 
-    if (darkMode) {
+    if (!storedTheme) {
+      localStorage.setItem('theme', 'dark');
       document.documentElement.classList.add('dark');
-    } else if (lightMode) {
+    } else if (storedTheme === 'dark') {
+      document.documentElement.classList.add('dark');
+    } else {
       document.documentElement.classList.remove('dark');
     }
-    return;
   };
 
   const handleSystemThemeChange = () => {

--- a/pages/prompt-library.js
+++ b/pages/prompt-library.js
@@ -3,6 +3,7 @@ import Header from '../components/Header';
 import Layout, { GradientBackground } from '../components/Layout';
 import SEO from '../components/SEO';
 import { getGlobalData } from '../utils/global-data';
+import { useState } from 'react';
 
 const prompts = [
   {
@@ -28,9 +29,13 @@ const prompts = [
 ];
 
 export default function PromptLibrary({ globalData }) {
-  const copyPrompt = (text) => {
+  const [copiedId, setCopiedId] = useState(null);
+
+  const copyPrompt = (text, id) => {
     if (typeof navigator !== 'undefined') {
       navigator.clipboard.writeText(text);
+      setCopiedId(id);
+      setTimeout(() => setCopiedId(null), 1000);
     }
   };
 
@@ -54,10 +59,10 @@ export default function PromptLibrary({ globalData }) {
               <div className="flex items-start justify-between px-6 py-6 lg:py-10 lg:px-16">
                 <pre className="whitespace-pre-wrap">{prompt.text}</pre>
                 <button
-                  onClick={() => copyPrompt(prompt.text)}
-                  className="px-3 py-2 ml-4 text-sm text-white bg-primary rounded"
+                  onClick={() => copyPrompt(prompt.text, prompt.id)}
+                  className="px-3 py-2 ml-4 text-sm text-white bg-primary rounded transition"
                 >
-                  Copy
+                  {copiedId === prompt.id ? 'Copied' : 'Copy'}
                 </button>
               </div>
             </li>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -24,3 +24,7 @@ body {
   font-family: var(--font-secondary);
 }
 
+pre {
+  font-family: var(--font-secondary);
+}
+


### PR DESCRIPTION
## Summary
- reposition theme toggle to the top-right
- shrink toggle buttons
- default the site to dark mode on load
- apply Avenir font to prompts
- add quick feedback when copying prompts

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6876b0c77110832caa0c3a2b85a8f293